### PR TITLE
Set repo in manifest to point to rust-bitcoin org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.1 - 2024-09-24
+
+Transfer repository to `github.com/rust-bitcoin`. No other changes.
+
 # 0.1.0 - 2024-09-23
 
 Import code from `rust-bitcoin 0.32.2`, the only changes are to import

--- a/Cargo-minimal.lock
+++ b/Cargo-minimal.lock
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "psbt-v0"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo-recent.lock
+++ b/Cargo-recent.lock
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "psbt-v0"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "psbt-v0"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>", "Tobin C. Harding <me@tobin.cc>"]
 license = "CC0-1.0"
-repository = "https://github.com/tcharding/rust-psbt-v0/"
+repository = "https://github.com/rust-bitcoin/rust-psbt-v0/"
 description = "Partially Signed Bitcoin Transaction Format - BIP-174"
 categories = ["cryptography::cryptocurrencies"]
 keywords = [ "psbt", "bip-174", "bip174", "psbt-v0", "psbtv0"]


### PR DESCRIPTION
We just transferred this repo to the `rust-bitcoin` org. We need to update the link on `crates.io` because I remove the auto-redirect from my github account so I can fork the repo to work on it. To do so we need to release a new version, can be done as a patch version.

Update the manifest, bump the patch version, update the lock-files.